### PR TITLE
1.3: SIGINT, history

### DIFF
--- a/src/command_history/history_state.h
+++ b/src/command_history/history_state.h
@@ -1,7 +1,7 @@
 #ifndef HISTORY_STATE_H
 # define HISTORY_STATE_H
 
-# define MAX_HIST 100 //temp for debug, make 200 before pushing
+# define MAX_HIST 200
 
 /*
 ** num_lines == number of lines filled
@@ -19,4 +19,5 @@ typedef struct s_history
 	int		last_shown_line;
 	int		iter_mode;
 }				t_history;
+
 #endif

--- a/src/command_history/update_history.c
+++ b/src/command_history/update_history.c
@@ -29,13 +29,15 @@ int	add_history_line(t_history *history, t_line *cmd_line)
 
 	if (history->num_lines + 1 > MAX_HIST)
 		overlap_history(history);
+	else if (history->saved_temp_input[MAX_HIST] == NULL
+		&& cmd_line->buf[0] == '\0')
+		return (1);
 	else
 		history->num_lines++;
 	history->last_shown_line = history->num_lines - 1;
 	i = history->last_shown_line;
 	if (history->saved_temp_input[MAX_HIST] != NULL
-		&& ft_strncmp(history->saved_temp_input[MAX_HIST], cmd_line->buf,
-			ft_strlen(history->saved_temp_input[MAX_HIST])) == 0)
+		&& ft_strcmp(history->saved_temp_input[MAX_HIST], cmd_line->buf) == 0)
 		history->lines[i] = ft_strdup(history->saved_temp_input[MAX_HIST]);
 	else
 		history->lines[i] = ft_strdup(cmd_line->buf);

--- a/src/main.c
+++ b/src/main.c
@@ -12,7 +12,6 @@ t_shell	*g_shell = NULL;
 
 int	shell_event_loop(t_shell *shell)
 {
-	struct termios	origin_attr;
 	int				parser_result;
 	t_treenode		tree;
 	t_redirection	redir;
@@ -23,11 +22,10 @@ int	shell_event_loop(t_shell *shell)
 		shell->redir = &redir;
 		init_tree(shell);
 		write_prompt();
-		catch_signals();
 		while (shell->is_command_executed != 1)
-			if (read_input(shell, &origin_attr) == ERROR)
+			if (read_input(shell) == ERROR)
 				return (ERROR);
-		reset_input_mode(&origin_attr, 0);
+		reset_input_mode(shell, 0);
 		parser_result = parse_command_line(shell);
 		if (parser_result == -1)
 			return (ERROR);
@@ -52,6 +50,7 @@ int	main(int argc, char **argv)
 	g_shell = &shell;
 	ft_bzero(&shell, sizeof(t_shell));
 	init_shell(&shell);
+	catch_signals();
 	if (shell_event_loop(&shell) == ERROR)
 	{
 		g_shell = NULL;

--- a/src/reader/command_line_state.h
+++ b/src/reader/command_line_state.h
@@ -6,7 +6,7 @@
 
 # define BUF_SIZE ARG_MAX
 
-# define PROMPT "minishell-1.2$ "
+# define PROMPT "minishell-1.3$ "
 
 typedef struct s_line
 {

--- a/src/reader/read_command_line.c
+++ b/src/reader/read_command_line.c
@@ -7,9 +7,9 @@
 
 #include <unistd.h>
 
-int	read_input(t_shell *shell, struct termios *origin_attr)
+int	read_input(t_shell *shell)
 {
-	if (!set_input_mode(origin_attr))
+	if (!set_input_mode(shell))
 		return (ERROR);
 	if (read_command_line(STDIN_FILENO, shell) == -1)
 	{

--- a/src/reader/read_command_line.h
+++ b/src/reader/read_command_line.h
@@ -6,8 +6,6 @@
 # include "command_line_state.h"
 # include "../shell_state.h"
 
-# include <termios.h>
-
 //  ANSI escape sequences, which extend the functions available with the control
 // codes:
 # define ESC '\x1b'
@@ -22,8 +20,8 @@ void	write_prompt(void);
 /*
 ** Set input mode with the termios struct:
 */
-int		set_input_mode(struct termios *origin_attr);
-int		reset_input_mode(struct termios *origin_attr, int error_code);
+int		set_input_mode(t_shell *shell);
+int		reset_input_mode(t_shell *shell, int error_code);
 
 /*
 ** Command line:
@@ -35,7 +33,7 @@ void	free_command_line(t_line *cmd_line);
 int		update_cmd_line(char *new_line, t_line *cmd_line);
 void	erase_current_line(t_line *cmd_line);
 
-int		read_input(t_shell *shell, struct termios *origin_attr);
+int		read_input(t_shell *shell);
 int		read_command_line(int fd, t_shell *shell);
 void	capture_keystrokes(int fd, char ch, t_shell *shell);
 

--- a/src/reader/set_term_attr.c
+++ b/src/reader/set_term_attr.c
@@ -22,28 +22,33 @@
 **
 */
 
-int	set_input_mode(struct termios *origin_attr)
+int	set_input_mode(t_shell *shell)
 {
-	if (!isatty (STDIN_FILENO) || tcgetattr(STDIN_FILENO, origin_attr) < 0)
+	struct termios	attributes;
+
+	if (!isatty(STDIN_FILENO)
+		|| tcgetattr(STDIN_FILENO, &shell->origin_attr) < 0
+		|| tcgetattr(STDIN_FILENO, &attributes) < 0)
 	{
 		errno = ENOTTY;
 		return (0);
 	}
-	(*origin_attr).c_lflag &= ~(ICANON | ECHO);
-	if (tcsetattr(STDIN_FILENO, TCSAFLUSH, origin_attr) < 0)
+	attributes.c_lflag &= ~(ICANON | ECHO);
+	attributes.c_cc[VTIME] = 0;
+	attributes.c_cc[VMIN] = 1;
+	if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &attributes) < 0)
 	{
 		printf("Error. Unable to set one or more terminal attributes.\n");
 		return (0);
 	}
-	if (((*origin_attr).c_lflag & (ECHO | ICANON)))
-		return (reset_input_mode(origin_attr, EINVAL));
+	if ((attributes.c_lflag & (ECHO | ICANON)))
+		return (reset_input_mode(shell, EINVAL));
 	return (1);
 }
 
-int	reset_input_mode(struct termios *origin_attr, int error_code)
+int	reset_input_mode(t_shell *shell, int error_code)
 {
-	(*origin_attr).c_lflag |= (ECHO | ICANON);
-	tcsetattr(STDIN_FILENO, TCSANOW, origin_attr);
+	tcsetattr(STDIN_FILENO, TCSANOW, &shell->origin_attr);
 	if (error_code == 0)
 		return (1);
 	else

--- a/src/shell_state.h
+++ b/src/shell_state.h
@@ -6,6 +6,8 @@
 # include "term_cap/termcap_codes.h"
 # include "executor/environment/environment.h"
 
+# include <termios.h>
+
 # define ERROR 1
 # define SUCCESS 0
 
@@ -45,6 +47,7 @@ typedef struct s_shell
 	t_redirection	*redir;
 	char			*term_buffer;
 	t_envlist		*env_list;
+	struct termios	origin_attr;
 	int				is_command_executed;
 	int				exit_code;
 	int				minishell_exits;

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -15,7 +15,6 @@ void	termination_handler(int signum)
 	if (signum == SIGINT)
 	{
 		g_shell->exit_code = 1;
-		g_shell->is_command_executed = 1;
 		clear_command_line(&g_shell->cmd_line);
 		ft_putstr_fd("\n\r", STDOUT_FILENO);
 		if (g_shell->syntax_tree->data == NULL)


### PR DESCRIPTION
SIGINT: removed flag is_command_executed from signals
history for empty line is not saved
saving original termios attributes into the shell structure to reset the mode.